### PR TITLE
feat: sql database connected

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-
+spring.datasource.url=jdbc:mysql://localhost:3306/agro_services
+spring.datasource.username=root
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
- `spring.datasource.url=jdbc:mysql://localhost:3306/agro_services`: especifica la URL de conexión de la base de datos MySQL
- `spring.datasource.username=root`: especifica el nombre se usuario de la base de datos.
- `spring.datasource.password=`: especifica la contraseña del usuario de la base de datos.
- `spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver`: nombre de la clase del controlador JDBC para MySQL que SpringBoot utilizará para conectarse a la base de datos MySQL.
- `spring.jpa.show-sql=true`: permite mostrar en la consola las consultas SQL que genera cuando interactúa con la base de datos.
- `spring.jpa.hibernate.ddl-auto=update`: ajusta automáticamente la estructura de la base de datos para que coincida con el modelo de datos de la aplicación.
- `spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect`: establece el dialecto de Hibernate para trabajar con  la base de datos MySQL.








